### PR TITLE
fixed encoding in 2nd element of shell_command on line 15

### DIFF
--- a/alfred_modal_mode.json
+++ b/alfred_modal_mode.json
@@ -12,7 +12,7 @@
           }
         },
         "to": [{
-          "shell_command": "'/Library/Application Support/org.pqrs/Karabiner-Elements/bin/karabiner_cli' --set-variables '{\"layer_alfred_modal_mode\":1}' & 'path/to/alfred_modal_mode.applescript' \"modal_01\" \"com.nathan.modaldemo\" && '/Library/Application Support/org.pqrs/Karabiner-Elements/bin/karabiner_cli' --set-variables '{\"layer_alfred_modal_mode\":0}'"
+          "shell_command": "'/Library/Application Support/org.pqrs/Karabiner-Elements/bin/karabiner_cli' --set-variables '{\"layer_alfred_modal_mode\":1}' & 'path/to/alfred_modal_mode.applescript' modal_01 com.nathan.modaldemo && '/Library/Application Support/org.pqrs/Karabiner-Elements/bin/karabiner_cli' --set-variables '{\"layer_alfred_modal_mode\":0}'"
         }],
         "conditions": [{
           "name": "layer_alfred_modal_mode",


### PR DESCRIPTION
changed part of line 15 from:

'path/to/alfred_modal_mode.applescript' \"modal_01\" \"com.nathan.modaldemo\"

to:

'path/to/alfred_modal_mode.applescript' modal_01 com.nathan.modaldemo